### PR TITLE
Bump version to 1.1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-simplymadeapps",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "ESLint config for Simply Made Apps",
   "homepage": "https://github.com/simplymadeapps/eslint-config-simplymadeapps",
   "license": "MIT",


### PR DESCRIPTION
I had previously published a version 1.1.5, so I had to bump the version to 1.1.6