### PR TITLE
Don't allow braces around props that are strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,6 +99,7 @@ module.exports = {
       "error",
       "as-needed"
     ],
+    "react/jsx-curly-brace-presence": [1, { "props": "never", "children": "ignore" }],
     "react/jsx-no-literals": 1,
     "react/jsx-uses-vars": 1,
     "sort-class-members/sort-class-members": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-simplymadeapps",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "ESLint config for Simply Made Apps",
   "homepage": "https://github.com/simplymadeapps/eslint-config-simplymadeapps",
   "license": "MIT",


### PR DESCRIPTION
This autofixes, so:

```jsx
<div id={"hello"}></div>
```

Becomes:

```jsx
<div id="hello"></div>
```