### PR TITLE
Add 'sort-imports' rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -134,6 +134,18 @@ module.exports = {
         "stopAfterFirstProblem": true
       }
     ],
+    "sort-imports": [
+      "error",
+      {
+        "ignoreCase": true,
+        "memberSyntaxSortOrder": [
+          "all",
+          "single",
+          "multiple",
+          "none"
+        ]
+      }
+    ],
     "sort-keys": ["error", "asc", { "caseSensitive": false }],
     "unicorn/prevent-abbreviations": "off"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-simplymadeapps",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "ESLint config for Simply Made Apps",
   "homepage": "https://github.com/simplymadeapps/eslint-config-simplymadeapps",
   "license": "MIT",


### PR DESCRIPTION
This enforces the sort order of importing node modules. They are sorted in alphabetical order, but the rule also requires that you group your imports and sort the groups properly. Here's where I settled on grouping everything. I went with the order `"all", "single", "multiple", "none"`. Each of the imports must be in alphabetical order within their groups, and the items in each multiple import must be in order as well.

```js
import * as fs from "fs";
import * as path from "path";
import { app } from "electron";
import KeysManager from "../../../src/main/utils/keys-manager";
import S3 from "aws-sdk/clients/s3";
import LogManager, { S3_APP_LOGS_PATH, S3_APP_NAME_PATH } from "../../../src/main/utils/log-manager";
import "./css/global.css";
```

**"all"**

```js
import * as fs from "fs";
import * as path from "path";
```

**"single"**

```js
import { app } from "electron";
import KeysManager from "../../../src/main/utils/keys-manager";
import S3 from "aws-sdk/clients/s3";
```

**"multiple"**

```js
import LogManager, { S3_APP_LOGS_PATH, S3_APP_NAME_PATH } from "../../../src/main/utils/log-manager";
```

**"none"**

```js
import "./css/global.css";
```