### PR TITLE
Enable "curly" and "import/first" rules as errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,6 +44,7 @@ module.exports = {
     ],
     "func-style": ["error", "declaration"],
     "guard-for-in": "off",
+    "import/first": "error",
     "import/no-extraneous-dependencies": "off",
     "import/no-unassigned-import": "off",
     "import/no-unresolved": "off",

--- a/index.js
+++ b/index.js
@@ -34,6 +34,7 @@ module.exports = {
   ],
   "rules": {
     "capitalized-comments": "off",
+    "curly": "error",
     "default-param-last": "off",
     "eqeqeq": [
       "error",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-simplymadeapps",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "ESLint config for Simply Made Apps",
   "homepage": "https://github.com/simplymadeapps/eslint-config-simplymadeapps",
   "license": "MIT",


### PR DESCRIPTION
### curly

This rule supports auto-fix. 

I like the single line for guard clauses, but there's not a way to allow it for guard clauses and then enforce for assigning a variable or calling a method. I'd rather give it up for guard clauses so it can be enforced everywhere.

#### Bad

```js
if (foo === bar) return true;
```

#### Good

```js
if (foo === bar) {
  return true;
}
```

### import/first

This rule supports auto-fix.

Ran into this example a couple days ago. We import first everywhere, but I can see how it might be confusing that `jest.mock` can actually come after the import statements. This enforces that imports always come before any other statements.

#### Bad

```js
jest.mock("electron");

import electron from "electron";
```

#### Good

```js
import electron from "electron";

jest.mock("electron");
```