### PR TITLE
Add plugins for jest rules and formatting

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,9 @@ module.exports = {
     "plugin:unicorn/recommended",
     "prettier",
     "prettier/react",
-    "plugin:jsdoc/recommended"
+    "plugin:jsdoc/recommended",
+    "plugin:jest/recommended",
+    "plugin:jest-formatting/strict"
   ],
   "globals": {
     "afterAll": true,
@@ -27,6 +29,8 @@ module.exports = {
   },
   "plugins": [
     "import",
+    "jest",
+    "jest-formatting",
     "prettier",
     "react",
     "sort-class-members",
@@ -50,6 +54,8 @@ module.exports = {
     "import/no-unassigned-import": "off",
     "import/no-unresolved": "off",
     "import/order": "off",
+    "jest/no-disabled-tests": "off",
+    "jest/no-mocks-import": "off",
     "jsdoc/require-description": [
       "error",
       {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-simplymadeapps",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "description": "ESLint config for Simply Made Apps",
   "homepage": "https://github.com/simplymadeapps/eslint-config-simplymadeapps",
   "license": "MIT",
@@ -22,7 +22,8 @@
     "eslint-plugin-prettier": "^3.1.2",
     "eslint-plugin-react": "^7.17.0",
     "eslint-plugin-sort-class-members": "^1.6.0",
-    "eslint-plugin-unicorn": "^14.0.1"
+    "eslint-plugin-unicorn": "^14.0.1",
+    "typescript": "^3.9.5"
   },
   "peerDependencies": {
     "eslint": ">=6.7.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-simplymadeapps",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "ESLint config for Simply Made Apps",
   "homepage": "https://github.com/simplymadeapps/eslint-config-simplymadeapps",
   "license": "MIT",
@@ -16,6 +16,8 @@
     "eslint-config-prettier": "^6.7.0",
     "eslint-config-xo": "^0.27.2",
     "eslint-plugin-import": "^2.19.1",
+    "eslint-plugin-jest": "^23.17.1",
+    "eslint-plugin-jest-formatting": "^2.0.0",
     "eslint-plugin-jsdoc": "^18.4.3",
     "eslint-plugin-prettier": "^3.1.2",
     "eslint-plugin-react": "^7.17.0",


### PR DESCRIPTION
We weren't really violating any of the recommended rules from the jest plugin. I found one duplicate title, which was nice that it was caught by ESLint. We violated the heck out of the try/catch rule though, and I'm cool with the change.

### No try/catch allowed in tests

```js
try {
  await LogManager.deleteFile("2019-04-01.log");
} catch (error) {
  expect(error).toBe(mockError);
}
```

The try/catch becomes:

```js
await expect(LogManager.deleteFile("2019-04-01.log")).rejects.toThrow(mockError);
```

Here's the basic formatting changes from the jest formatting plugin:

### Bad

```js
describe("Component", () => {
  let props;
  beforeEach(() => {
    props = { mock: "props" };
  });
  it("does something", async () => {
    expect.assertions(1);
    doSomething();
    anotherThing();
    expect(props).toEqual("props");
  });
});
```

### Good

```js
describe("Component", () => {
  let props;

  beforeEach(() => {
    props = { mock: "props" };
  });

  it("does something", async () => {
    expect.assertions(1);

    doSomething();
    anotherThing();

    expect(props).toEqual("props");
  });
});
```

The formatting plugin auto-fixes the padding around blocks and expect statements, so always nice to get consistent formatting by just saving the file.