### PR TITLE
FAF-131: Use 'babel-eslint' parser

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ module.exports = {
     "it": true,
     "jest": true
   },
+  "parser": "babel-eslint",
   "parserOptions": {
     "ecmaFeatures": {
       "jsx": true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-simplymadeapps",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "description": "ESLint config for Simply Made Apps",
   "homepage": "https://github.com/simplymadeapps/eslint-config-simplymadeapps",
   "license": "MIT",
@@ -26,6 +26,7 @@
     "typescript": "^3.9.5"
   },
   "peerDependencies": {
+    "babel-eslint": ">=10.1.0",
     "eslint": ">=6.7.2",
     "prettier": ">=1.19.1"
   }


### PR DESCRIPTION
This allows ESLint to parse JS features enabled by Babel.