### PR TITLE
FAF-136: Extend 'jest/style' ESLint rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ module.exports = {
     "prettier/react",
     "plugin:jsdoc/recommended",
     "plugin:jest/recommended",
+    "plugin:jest/style",
     "plugin:jest-formatting/strict"
   ],
   "globals": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-simplymadeapps",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "description": "ESLint config for Simply Made Apps",
   "homepage": "https://github.com/simplymadeapps/eslint-config-simplymadeapps",
   "license": "MIT",


### PR DESCRIPTION
There was nothing stopping us from using a combination of `.toBe(null)` and `.toBeNull()` throughout our test suites. Same goes for `.toBeUndefined()` and `.toHaveLength()`. Why be forced to ask the question, "Why'd you decide to use `.toBeNull()` when we don't use it anywhere else?"

This will enforce using the named expectation and will auto-fix on save:

- `.toBe(null)` -> `.toBeNull()`
- `.toBe(undefined)` -> `.toBeUndefined()`
- `(array.length).toBe(5)` -> `(array).toHaveLength(5)`.