### PR TITLE
FAF-211: Add rule for requiring await when an async function is used

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,6 +118,7 @@ module.exports = {
     "react/jsx-no-literals": 1,
     "react/jsx-sort-props": [1, { "ignoreCase": true }],
     "react/jsx-uses-vars": 1,
+    "require-await": "error",
     "sort-class-members/sort-class-members": [
       2,
       {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-simplymadeapps",
-  "version": "1.5.7",
+  "version": "1.5.8",
   "description": "ESLint config for Simply Made Apps",
   "homepage": "https://github.com/simplymadeapps/eslint-config-simplymadeapps",
   "license": "MIT",


### PR DESCRIPTION
We have quite a few test blocks that are using `async` when the function doesn't need to be an `async` function.

```js
it("logs the action and dispatched the 'REAUTHENTICATE' action", async () => {
  const action = store.dispatch(reauthenticate());

  expect(action).toEqual({ type: REAUTHENTICATE });
  expect(log.debug.mock.calls[0][0]).toEqual("[Redux] [reauthenticate] dispatch action");
});
```

This rule will prevent that. It does not auto-fix, which is good because you wouldn't want it to delete the `async` for you because you hit save before using the `await` keyword in your function.