### PR TITLE
FAF-564: Update rules to include 'no-duplicate-imports' to enforce single line imports from same module

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,6 +94,7 @@ module.exports = {
     ],
     "newline-before-return": "error",
     "no-alert": "off",
+    "no-duplicate-imports": "error",
     "no-eq-null": "off",
     "no-unused-vars": [
       "error",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-simplymadeapps",
-  "version": "1.5.11",
+  "version": "1.5.12",
   "description": "ESLint config for Simply Made Apps",
   "homepage": "https://github.com/simplymadeapps/eslint-config-simplymadeapps",
   "license": "MIT",


### PR DESCRIPTION
Now that our Renderer actions on Desktop are all imported from `"@renderer/actions"`, I want to add the `no-duplicate-imports` rule so when we have multiple actions imported for the same component, they get grouped together.

### Bad

This comes straight from the `CompanyFavorites` component:

```js
import { addNewCurrentCompanyFavorite } from "@renderer/actions";
import { changeNewCurrentCompanyFavorite } from "@renderer/actions";
import { connect } from "react-redux";
import FavoritesForm from "@components/favorites-form";
import React from "react";
import { removeNewCurrentCompanyFavorite } from "@renderer/actions";
import { resetNewCurrentCompanyFavorites } from "@renderer/actions";
import { setNewCurrentCompanyFavorites } from "@renderer/actions";
import SettingsScrollView from "./settings-scroll-view";
import { sortNewCurrentCompanyFavorites } from "@renderer/actions";
import { updateCurrentCompanyFavorites } from "@renderer/actions";
import { withTranslation } from "react-i18next";
import Section, { SectionContent, SectionHeader } from "./section";
```

### Good

I like how all of the actions have are grouped together with this rule enabled:

```js
import { connect } from "react-redux";
import FavoritesForm from "@components/favorites-form";
import React from "react";
import SettingsScrollView from "./settings-scroll-view";
import { withTranslation } from "react-i18next";
import {
  addNewCurrentCompanyFavorite,
  changeNewCurrentCompanyFavorite,
  removeNewCurrentCompanyFavorite,
  resetNewCurrentCompanyFavorites,
  setNewCurrentCompanyFavorites,
  sortNewCurrentCompanyFavorites,
  updateCurrentCompanyFavorites
} from "@renderer/actions";
import Section, { SectionContent, SectionHeader } from "./section";
```